### PR TITLE
Update grafana image to latest

### DIFF
--- a/roles/provision-prometheus-apb/defaults/main.yml
+++ b/roles/provision-prometheus-apb/defaults/main.yml
@@ -8,7 +8,7 @@ prometheus_proxy_port: 4180
 # Grafana values
 grafana_image: "docker.io/grafana/grafana"
 # TODO: Change to 4.7.0 when a tag is available
-grafana_version: "master"
+grafana_version: "latest"
 grafana_port: 3000
 grafana_ini_configmap_name: "grafana-ini-configmap"
 grafana_ini_configmap_volume_name: "grafana-ini-configmap-volume"


### PR DESCRIPTION
## Motivation

After *successful* provision of grafana it starts miss-configured. 
All files are in right directories, but it seems that master image comes with broken json format. 

It also seems that json format is not stable and dashboards will probably will need to be reconfigured after 4.7.0 release which may be created soon. Using latest image resolves the problem with missing dashboards. Users will still need to replicate datasource . 

Current images.
```
master 4 days ago
latest  25 days ago
```

See: https://hub.docker.com/r/grafana/grafana/tags/

![screen shot 2018-01-04 at 12 23 05 pm](https://user-images.githubusercontent.com/981838/34675221-d9298bc2-f480-11e7-8aba-1691d570e93f.png)

